### PR TITLE
Fix searchbar filter event

### DIFF
--- a/src/app/biblia/biblia.page.ts
+++ b/src/app/biblia/biblia.page.ts
@@ -138,7 +138,8 @@ export class BibliaPage implements OnInit {
   }
 
   filtrarResultados(event: any) {
-    const term = event.target.value.toLowerCase();
+    const searchValue = event.detail?.value ?? event.target?.value ?? '';
+    const term = searchValue.toLowerCase();
     this.resultados = [];
 
     // Filtra livros


### PR DESCRIPTION
## Summary
- handle both `event.detail.value` and `event.target.value` when filtering verses

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439f92e2c48327bf08e8a0beacd4e6